### PR TITLE
Added Jump and Turn functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ enc_temp_folder/*
 # C++ Debugging Symbols
 *.pdb
 *.idb
+
+Content/ParagonLtBelica/*

--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -78,6 +78,8 @@ DefaultViewportMouseCaptureMode=CapturePermanently_IncludingInitialMouseDown
 DefaultViewportMouseLockMode=LockOnCapture
 FOVScale=0.011110
 DoubleClickTime=0.200000
++ActionMappings=(ActionName="Jump",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=SpaceBar)
++ActionMappings=(ActionName="Jump",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=Gamepad_FaceButton_Bottom)
 +AxisMappings=(AxisName="MoveForward",Scale=1.000000,Key=W)
 +AxisMappings=(AxisName="MoveForward",Scale=-1.000000,Key=S)
 +AxisMappings=(AxisName="MoveForward",Scale=1.000000,Key=Gamepad_LeftX)

--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -84,6 +84,12 @@ DoubleClickTime=0.200000
 +AxisMappings=(AxisName="MoveRight",Scale=1.000000,Key=D)
 +AxisMappings=(AxisName="MoveRight",Scale=-1.000000,Key=A)
 +AxisMappings=(AxisName="MoveRight",Scale=1.000000,Key=Gamepad_LeftY)
++AxisMappings=(AxisName="TurnRate",Scale=1.000000,Key=Right)
++AxisMappings=(AxisName="LookUpRate",Scale=1.000000,Key=Up)
++AxisMappings=(AxisName="TurnRate",Scale=-1.000000,Key=Left)
++AxisMappings=(AxisName="TurnRate",Scale=1.000000,Key=Gamepad_RightX)
++AxisMappings=(AxisName="LookUpRate",Scale=-1.000000,Key=Down)
++AxisMappings=(AxisName="LookUpRate",Scale=1.000000,Key=Gamepad_RightY)
 DefaultPlayerInputClass=/Script/EnhancedInput.EnhancedPlayerInput
 DefaultInputComponentClass=/Script/EnhancedInput.EnhancedInputComponent
 DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.DefaultVirtualJoysticks

--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -90,6 +90,8 @@ DoubleClickTime=0.200000
 +AxisMappings=(AxisName="TurnRate",Scale=1.000000,Key=Gamepad_RightX)
 +AxisMappings=(AxisName="LookUpRate",Scale=-1.000000,Key=Down)
 +AxisMappings=(AxisName="LookUpRate",Scale=1.000000,Key=Gamepad_RightY)
++AxisMappings=(AxisName="Turn",Scale=1.000000,Key=MouseX)
++AxisMappings=(AxisName="LookUp",Scale=-1.000000,Key=MouseY)
 DefaultPlayerInputClass=/Script/EnhancedInput.EnhancedPlayerInput
 DefaultInputComponentClass=/Script/EnhancedInput.EnhancedInputComponent
 DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.DefaultVirtualJoysticks

--- a/Source/ProjectSentinel/Private/SentinelRebel.cpp
+++ b/Source/ProjectSentinel/Private/SentinelRebel.cpp
@@ -87,4 +87,7 @@ void ASentinelRebel::SetupPlayerInputComponent(UInputComponent* PlayerInputCompo
 	PlayerInputComponent->BindAxis("MoveRight", this, &ASentinelRebel::MoveRight);
 	PlayerInputComponent->BindAxis("TurnRate", this, &ASentinelRebel::TurnAtRate);
 	PlayerInputComponent->BindAxis("LookUpRate", this, &ASentinelRebel::LookUpAtRate);
+
+	PlayerInputComponent->BindAxis("Turn", this, &APawn::AddControllerYawInput);
+	PlayerInputComponent->BindAxis("LookUp", this, &APawn::AddControllerPitchInput);
 }

--- a/Source/ProjectSentinel/Private/SentinelRebel.cpp
+++ b/Source/ProjectSentinel/Private/SentinelRebel.cpp
@@ -7,19 +7,20 @@
 
 // Sets default values
 ASentinelRebel::ASentinelRebel()
+	: _mBaseTurnRate(45.0f), _mBaseLookUpRate(45.0f)
 {
  	// Set this character to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;
 
 	// Create a camera boom (pulls in towards the character if there is a collision)
-	_mcameraBoom = CreateDefaultSubobject<USpringArmComponent>(TEXT("CameraBoom"));
-	_mcameraBoom->SetupAttachment(RootComponent);
-	_mcameraBoom->TargetArmLength = 300.0f; // The camera follows at this distance behind the character
-	_mcameraBoom->bUsePawnControlRotation = true; // Rotate the arm based on the controller
+	_mCameraBoom = CreateDefaultSubobject<USpringArmComponent>(TEXT("CameraBoom"));
+	_mCameraBoom->SetupAttachment(RootComponent);
+	_mCameraBoom->TargetArmLength = 300.0f; // The camera follows at this distance behind the character
+	_mCameraBoom->bUsePawnControlRotation = true; // Rotate the arm based on the controller
 
-	_mfollowCamera = CreateDefaultSubobject<UCameraComponent>(TEXT("FollowCamera"));
-	_mfollowCamera->SetupAttachment(_mcameraBoom, USpringArmComponent::SocketName); // Attach camera to the end of boom
-	_mfollowCamera->bUsePawnControlRotation = false; // Camera does not rotate relative to arm
+	_mFollowCamera = CreateDefaultSubobject<UCameraComponent>(TEXT("FollowCamera"));
+	_mFollowCamera->SetupAttachment(_mCameraBoom, USpringArmComponent::SocketName); // Attach camera to the end of boom
+	_mFollowCamera->bUsePawnControlRotation = false; // Camera does not rotate relative to arm
 }
 
 // Called when the game starts or when spawned
@@ -57,6 +58,18 @@ void ASentinelRebel::MoveRight(float value)
 	}
 }
 
+void ASentinelRebel::TurnAtRate(float rate)
+{
+	// Calculate delta for this frame from the rate information
+	AddControllerYawInput(rate * _mBaseTurnRate * GetWorld()->GetDeltaSeconds()); // deg/sec * sec/frame
+}
+
+void ASentinelRebel::LookUpAtRate(float rate)
+{
+	// Calculate delta for this frame from the rate information
+	AddControllerPitchInput(rate * _mBaseLookUpRate * GetWorld()->GetDeltaSeconds()); // deg/sec * sec/frame
+}
+
 // Called every frame
 void ASentinelRebel::Tick(float DeltaTime)
 {
@@ -72,4 +85,6 @@ void ASentinelRebel::SetupPlayerInputComponent(UInputComponent* PlayerInputCompo
 
 	PlayerInputComponent->BindAxis("MoveForward", this, &ASentinelRebel::MoveForward);
 	PlayerInputComponent->BindAxis("MoveRight", this, &ASentinelRebel::MoveRight);
+	PlayerInputComponent->BindAxis("TurnRate", this, &ASentinelRebel::TurnAtRate);
+	PlayerInputComponent->BindAxis("LookUpRate", this, &ASentinelRebel::LookUpAtRate);
 }

--- a/Source/ProjectSentinel/Private/SentinelRebel.cpp
+++ b/Source/ProjectSentinel/Private/SentinelRebel.cpp
@@ -90,4 +90,7 @@ void ASentinelRebel::SetupPlayerInputComponent(UInputComponent* PlayerInputCompo
 
 	PlayerInputComponent->BindAxis("Turn", this, &APawn::AddControllerYawInput);
 	PlayerInputComponent->BindAxis("LookUp", this, &APawn::AddControllerPitchInput);
+
+	PlayerInputComponent->BindAction("Jump", IE_Pressed, this, &ACharacter::Jump);
+	PlayerInputComponent->BindAction("Jump", IE_Released, this, &ACharacter::StopJumping);
 }

--- a/Source/ProjectSentinel/Public/SentinelRebel.h
+++ b/Source/ProjectSentinel/Public/SentinelRebel.h
@@ -25,6 +25,16 @@ protected:
 	/** Called for side to side input */
 	void MoveRight(float value);
 
+	/** Called via input to turn at a given rate.
+	* @param rate This is a normalized rate, i.e. 1.0 means 100% desired turn rate
+	*/
+	void TurnAtRate(float rate);
+
+	/** Called via input to look up/down at a given rate.
+	* @param rate This is a normalized rate, i.e 1.0 means 100% desired turn rate
+	*/
+	void LookUpAtRate(float rate);
+
 public:	
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
@@ -35,14 +45,23 @@ public:
 private:
 	/** Camera boom positioning the camera behind the character */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
-	class USpringArmComponent* _mcameraBoom;
+	class USpringArmComponent* _mCameraBoom;
 
-	class UCameraComponent* _mfollowCamera;
+	/** Follow camera attached to the end of Camera Boom */
+	class UCameraComponent* _mFollowCamera;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
+	/** Base turn rate, in deg/sec. Other scaling may affect final turn rate */
+	float _mBaseTurnRate;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
+	/** Base Look up/down rate, in deg/sec. Other scaling may affect final turn rate */
+	float _mBaseLookUpRate;
 
 public:
 	/** Returns CameraBoom subobject */
 	FORCEINLINE USpringArmComponent* GetCameraBoom() const
 	{
-		return _mcameraBoom;
+		return _mCameraBoom;
 	}
 };


### PR DESCRIPTION
Added Turn Functionality.
- Arrow keys helps for making player look up/down and turn left and right around.
- For Turn I have used AddControllerYawInput. (Y axis would be Yaw in Unity, Z axis would be Yaw in Unreal).
- For Look up/down I have used AddControllerPitchInput. (X axis would be Pitch in Unity, Y axis would be Pitch in Unreal).

Added Turn Functionality using Mouse.
- For Turn I have used the available method APawn::AddControllerYawInput. (Y axis would be Yaw in Unity, Z axis would be Yaw in Unreal).
- For Look up/down I have used the available method APawn::AddControllerPitchInput. (X axis would be Pitch in Unity, Y axis would be Pitch in Unreal).

Added Jump Functionality.
- Spacebar is now used for Jump Functionality.
- On Spacebar press, Jump functionality from ACharacter is executed.
- On Spacebar release, StopJumping functionality from ACharacter is executed.